### PR TITLE
Several memory issues resolved & friendlier behavior of vtcli

### DIFF
--- a/src/sequence.cpp
+++ b/src/sequence.cpp
@@ -170,6 +170,7 @@ bool Video::add(string name, string location) {
             retval = VT_FAIL;
         }
     }
+    this->closeVideo();
     
 #endif
     
@@ -236,7 +237,7 @@ bool VideoPlayer::play() {
 
     if (!videos.empty()) {
         cap = cv::VideoCapture(videos.front().getDataLocation());
-        int fps = (int) cap.get(CV_CAP_PROP_FPS);
+        fps = (int) cap.get(CV_CAP_PROP_FPS);
     }
     // TODO: images, ...
     // frame = cv::imread("img.jpg");
@@ -247,14 +248,18 @@ bool VideoPlayer::play() {
 
     // toz a jedem
     if(cap.isOpened()) {
-        cv::namedWindow("video",1);
+        cv::namedWindow("video", CV_WINDOW_AUTOSIZE);
         cv::Mat frame;
         while(1)
         {
             cap >> frame;
+            if (frame.empty()) {
+                break;
+            }
             cv::imshow("video", frame);
             if(cv::waitKey(1000 / fps) >= 0) break; // correct the with real timer!
         }
+        cap.release();
         cv::destroyWindow("video");
     }
     else {

--- a/src/vtapi.cpp
+++ b/src/vtapi.cpp
@@ -46,7 +46,7 @@ VTApi::VTApi(int argc, char** argv) {
         cerr << "Aborting: Database connection info missing. Use \"-h\" for help. " << endl;
         cerr << "Use config file (--config=\"/path/to/somefile.conf\") or check help for command line option \"-c\"." << endl;
         cmdline_parser_free (&args_info);
-        vt_destruct(cli_params);
+        free(cli_params);
         throw new std::exception();
     }
     // TODO: user authentization here
@@ -57,7 +57,7 @@ VTApi::VTApi(int argc, char** argv) {
         cerr << "Error parsing config arguments" << endl;
     }
     cmdline_parser_free (&args_info);
-    vt_destruct(cli_params);
+    free(cli_params);
 }
 
 VTApi::VTApi(const string& configFile) {
@@ -285,8 +285,9 @@ void VTApi::testGenericClasses() {
     kvFloatA.print();
 
     cout << "** CLEANUP" << endl;
-    vt_destruct(int_deserial);
-    vt_destruct(fl_deserial);
+    vt_destructall(int_deserial);
+    vt_destructall(fl_deserial);
+    vt_destruct(arr_serial);
     vt_destruct(kvStringPt);
 
     cout << endl << "DONE testing generic classes.";
@@ -359,7 +360,7 @@ void VTApi::testInterval(Sequence *sequence) {
     cout << "USING sequence " << sequence->getSequence() << endl << endl;
 
     cout << "** SHOWING all intervals" << endl;
-    Interval* interval = sequence->newInterval();
+    Interval* interval = new Interval(*sequence, "test1out");
     interval->select->setLimit(10);
     // interval->select->from("intervals", "DESC_DENSE16_CSIFT_NoA_UNC_K32_o10_L01_KM_L12[1]");
     // interval->select->whereFloat("DESC_DENSE16_CSIFT_NoA_UNC_K32_o10_L01_KM_L12[1]", 0.0, ">");

--- a/vtcli.cpp
+++ b/vtcli.cpp
@@ -67,6 +67,9 @@ int VTCli::run() {
         if (do_help) {
             printHelp (command);
         }
+        else if (command.empty() && this->interact) {
+            continue;
+        }
         // commands
         else if (command.compare("select") == 0) {
             selectCommand (line);


### PR DESCRIPTION
- fixes in freeing memory
- fixes in non-closed or non-released opencv-resources
- fix when sequence reaches the final frame
- vtcli is now more clever and friendlier - empty command is ignored (instead of reporting error)
- other changes
